### PR TITLE
feat: Add filter for current session only

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim)
           name = "tmux",
           -- default options
           opts = {
+            -- suggest completions from all tmux panes
             all_panes = false,
+            -- suggest completions from current tmux session panes only
+            session_panes = false,
             capture_history = false,
             -- only suggest completions from `tmux` if the `trigger_chars` are
             -- used

--- a/lua/blink-cmp-tmux/init.lua
+++ b/lua/blink-cmp-tmux/init.lua
@@ -1,5 +1,6 @@
 ---@class blink-cmp-tmux.Opts
 ---@field all_panes boolean
+---@field session_panes boolean
 ---@field capture_history boolean
 ---@field triggered_only boolean
 ---@field trigger_chars string[]
@@ -7,6 +8,7 @@
 ---@type blink-cmp-tmux.Opts
 local default_opts = {
 	all_panes = false,
+	session_panes = false,
 	capture_history = false,
 	triggered_only = false,
 	trigger_chars = { "." },
@@ -75,7 +77,9 @@ function tmux:get_pane_ids()
 
 	if self.opts.all_panes then
 		table.insert(cmd, "-a")
-	end
+	elseif self.opts.session_panes then
+        table.insert(cmd, "-s")
+    end
 	vim.system(cmd, {
 		stdout = function(_, data)
 			if not data then


### PR DESCRIPTION
This is a small PR to add an option to provide suggestions only for the tmux pane of the current session nvim is in.

I use sessions a lot for different projects, and so mixing sessions causes a lot of false positives.

Let me know if I need any iteration on the code.