### PR TITLE
feat!: replace `all_panes` flag with `panels` string field for session-scoped filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim)
           name = "tmux",
           -- default options
           opts = {
+            -- suggest completions from all tmux panes
             all_panes = false,
+            -- suggest completions from current tmux session panes only
+            session_panes = false,
             capture_history = false,
             -- only suggest completions from `tmux` if the `trigger_chars` are
             -- used

--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim)
           name = "tmux",
           -- default options
           opts = {
-            -- suggest completions from all tmux panes
-            all_panes = false,
-            -- suggest completions from current tmux session panes only
-            session_panes = false,
+            -- `panes` option supports these values:
+            -- * `window`  - completions from current tmux window panes only
+            -- * `session` - completions from current tmux session panes only
+            -- * `all`     - completions from all tmux panes
+            panes = "window",
             capture_history = false,
             -- only suggest completions from `tmux` if the `trigger_chars` are
             -- used

--- a/lua/blink-cmp-tmux/init.lua
+++ b/lua/blink-cmp-tmux/init.lua
@@ -1,5 +1,6 @@
 ---@class blink-cmp-tmux.Opts
 ---@field all_panes boolean
+---@field session_panes boolean
 ---@field capture_history boolean
 ---@field triggered_only boolean
 ---@field trigger_chars string[]
@@ -7,6 +8,7 @@
 ---@type blink-cmp-tmux.Opts
 local default_opts = {
 	all_panes = false,
+	session_panes = false,
 	capture_history = false,
 	triggered_only = false,
 	trigger_chars = { "." },
@@ -75,7 +77,9 @@ function tmux:get_pane_ids()
 
 	if self.opts.all_panes then
 		table.insert(cmd, "-a")
-	end
+	elseif self.opts.session_panes then
+        table.insert(cmd, "-s")
+    end
 	vim.system(cmd, {
 		stdout = function(_, data)
 			if not data then

--- a/lua/blink-cmp-tmux/init.lua
+++ b/lua/blink-cmp-tmux/init.lua
@@ -1,14 +1,12 @@
 ---@class blink-cmp-tmux.Opts
----@field all_panes boolean
----@field session_panes boolean
+---@field panes string
 ---@field capture_history boolean
 ---@field triggered_only boolean
 ---@field trigger_chars string[]
 
 ---@type blink-cmp-tmux.Opts
 local default_opts = {
-	all_panes = false,
-	session_panes = false,
+	panes = "window",
 	capture_history = false,
 	triggered_only = false,
 	trigger_chars = { "." },
@@ -75,11 +73,11 @@ function tmux:get_pane_ids()
 	local ids = {}
 	local cmd = { "tmux", "list-panes", "-F", "'#{pane_id}'" }
 
-	if self.opts.all_panes then
+	if self.opts.panes == "all" then
 		table.insert(cmd, "-a")
-	elseif self.opts.session_panes then
-        table.insert(cmd, "-s")
-    end
+	elseif self.opts.panes == "session" then
+		table.insert(cmd, "-s")
+	end
 	vim.system(cmd, {
 		stdout = function(_, data)
 			if not data then


### PR DESCRIPTION
This allows getting completion from the current session only when using `panes = "session"`.

BREAKING CHANGE: `all_panes` boolean flag is removed, now `panes = "all"` should be used for the same.

This doesn't change the default behavior.

Changes are implemented as suggested in: https://github.com/mgalliou/blink-cmp-tmux/pull/1#issuecomment-3337031533